### PR TITLE
Adds initial association functionality

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,90 @@
+Bundler/OrderedGems:
+  Enabled: false
+
+Style/SafeNavigation:
+  Enabled: false
+
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation
+
+Layout/ParameterAlignment:
+  EnforcedStyle: with_fixed_indentation
+
+Layout/HashAlignment:
+  EnforcedLastArgumentHashStyle: ignore_implicit
+
+Layout/MultilineMethodCallBraceLayout:
+  EnforcedStyle: new_line
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: false
+
+Layout/LineLength:
+  Exclude:
+    - active_form.gemspec
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/ClassLength:
+  Exclude:
+    - test/**/*.rb
+
+Metrics/MethodLength:
+  Exclude:
+    - test/**/*.rb
+
+Metrics/AbcSize:
+  Exclude:
+    - test/**/*.rb
+
+Style/AsciiComments:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/GuardClause:
+  MinBodyLength: 2
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/Lambda:
+  EnforcedStyle: literal
+
+Style/MultilineBlockChain:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/SymbolArray:
+  MinSize: 5
+
+Style/TrailingUnderscoreVariable:
+  AllowNamedUnderscoreVariables: true
+
+Style/WordArray:
+  MinSize: 5
+
+Style/ExponentialNotation:
+  Enabled: false
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,0 +1,5 @@
+{
+  "result": {
+    "covered_percent": 100.0
+  }
+}

--- a/lib/active_form.rb
+++ b/lib/active_form.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 require "active_form/version"
+require "active_form/association"
+require "active_form/association_attribute_set"
+require "active_form/association_finder"
+require "active_form/association_attributes"
 
 module ActiveForm
 end

--- a/lib/active_form/association.rb
+++ b/lib/active_form/association.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module ActiveForm
+  class Association
+    attr_reader :id, :finder, :loaded
+
+    def initialize(id: nil, finder:, current_value: nil, loaded: false)
+      @id = id
+      @loaded = loaded
+      @current_value = current_value
+      @finder = finder
+    end
+
+    def current_value
+      return @current_value if loaded?
+
+      load_value!
+    end
+
+    def current_value=(new_value)
+      raise "Invalid Association" unless new_value.respond_to?(:id)
+
+      @loaded = true
+      @id = new_value.id
+      @current_value = new_value
+    end
+
+    def id=(new_id)
+      @loaded = false
+      @current_value = nil
+      @id = new_id
+    end
+
+    private
+
+    def loaded?
+      loaded
+    end
+
+    def load_value!
+      value = finder.find(id: id) if id
+
+      @loaded = true
+      @current_value = value
+    end
+  end
+end

--- a/lib/active_form/association_attribute_set.rb
+++ b/lib/active_form/association_attribute_set.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/object/deep_dup"
+
+module ActiveForm
+  class AssociationAttributeSet
+    def initialize(associations = {})
+      @associations = associations
+    end
+
+    def []=(name, value)
+      associations[name] = value
+    end
+
+    def read_association_value(name)
+      associations[name].current_value
+    end
+
+    def write_association_value(name, value)
+      associations[name].current_value = value
+    end
+
+    def to_hash
+      associations.transform_values(&:current_value)
+    end
+    alias to_h to_hash
+
+    def deep_dup
+      self.class.new(associations.deep_dup)
+    end
+
+    private
+
+    attr_reader :associations
+  end
+end

--- a/lib/active_form/association_attributes.rb
+++ b/lib/active_form/association_attributes.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+require "active_support/core_ext/class/attribute"
+
+module ActiveForm
+  module AssociationAttributes
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :association_set, instance_accessor: false,
+        default: AssociationAttributeSet.new
+    end
+
+    class_methods do
+      def association(assoc_name)
+        name = assoc_name.to_sym
+
+        build_association_attribute(name)
+        define_association_methods(name)
+      end
+
+      private
+
+      def build_association_attribute(name)
+        self.association_set = association_set.deep_dup
+
+        finder = AssociationFinder.new(name: name)
+        association_set[name] = Association.new(finder: finder)
+      end
+
+      def define_association_methods(name)
+        class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+          delegate :#{name}_id, :#{name}_id=, to: :#{name}
+
+          def #{name}
+            association_set.read_association("#{name}")
+          end
+
+          def #{name}=(new_assoc)
+            association_set.write_association("#{name}", new_value)
+          end
+        RUBY
+      end
+    end
+
+    attr_reader :association_set
+
+    def initialize(*)
+      @association_set = self.class.association_set.deep_dup
+      super
+    end
+  end
+end

--- a/lib/active_form/association_finder.rb
+++ b/lib/active_form/association_finder.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/string"
+
+module ActiveForm
+  class AssociationFinder
+    attr_reader :class_name
+
+    def initialize(name:)
+      @class_name = name.to_s.classify.constantize
+    end
+
+    def find(id:)
+      class_name.find_by(id: id)
+    end
+  end
+end

--- a/test/association_attribute_set_test.rb
+++ b/test/association_attribute_set_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "minitest/mock"
+
+module ActiveForm
+  class AssociationAttributeSetTest < Minitest::Test
+    FakeAssociation = Struct.new(:current_value)
+
+    def test_add_to_set
+      association_set = AssociationAttributeSet.new
+
+      association_set[:foo] = FakeAssociation.new
+
+      assert_equal({ foo: nil }, association_set.to_hash)
+    end
+
+    def test_read_association_value
+      association_set = AssociationAttributeSet.new
+
+      association_set[:foo] = FakeAssociation.new("foo value")
+
+      assert_equal("foo value", association_set.read_association_value(:foo))
+    end
+
+    def test_write_association_value
+      association_set = AssociationAttributeSet.new
+
+      association_set[:foo] = FakeAssociation.new("foo value")
+
+      association_set.write_association_value(:foo, "another foo value")
+
+      assert_equal(
+        "another foo value",
+        association_set.read_association_value(:foo)
+      )
+    end
+
+    def test_to_hash
+      association_set = AssociationAttributeSet.new
+
+      association_set[:foo] = FakeAssociation.new("foo value")
+
+      assert_equal({ foo: "foo value" }, association_set.to_hash)
+    end
+  end
+end

--- a/test/association_attributes_test.rb
+++ b/test/association_attributes_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "models/user"
+
+module ActiveForm
+  class AssociationAttributesTest < Minitest::Test
+    class SampleClass
+      include ActiveForm::AssociationAttributes
+
+      association :user
+    end
+
+    def test_generates_association_accessors
+      sample = SampleClass.new
+
+      assert_respond_to sample, :user
+      assert_respond_to sample, :user=
+    end
+
+    def test_generates_association_id_accessors
+      sample = SampleClass.new
+
+      assert_respond_to sample, :user_id
+      assert_respond_to sample, :user_id=
+    end
+  end
+end

--- a/test/association_finder_test.rb
+++ b/test/association_finder_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "models/user"
+
+module ActiveForm
+  class AssociationFinderTest < Minitest::Test
+    def test_find
+      finder = AssociationFinder.new(name: :user)
+
+      assert_equal("a result", finder.find(id: 42))
+    end
+  end
+end

--- a/test/association_test.rb
+++ b/test/association_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "minitest/mock"
+
+module ActiveForm
+  class AssociationTest < Minitest::Test
+    SimpleObject = Struct.new(:id, keyword_init: true)
+
+    def test_current_value_reader_when_loaded
+      finder = Minitest::Mock.new
+      association = Association.new(
+        finder: finder,
+        current_value: "something",
+        loaded: true
+      )
+
+      assert_equal("something", association.current_value)
+    end
+
+    def test_current_value_reader_when_not_loaded_and_with_id
+      finder = Minitest::Mock.new
+      association = Association.new(finder: finder, id: 123)
+
+      finder.expect(:find, "some value", [{ id: 123 }])
+
+      assert_equal("some value", association.current_value)
+      finder.verify
+    end
+
+    def test_current_value_reader_when_not_loaded_and_without_id
+      finder = Minitest::Mock.new
+      association = Association.new(finder: finder)
+
+      assert_nil(association.current_value)
+    end
+
+    def test_current_value_setter_with_valid_object
+      simple_object = SimpleObject.new(id: 321)
+      finder = Minitest::Mock.new
+      association = Association.new(finder: finder)
+
+      association.current_value = simple_object
+
+      assert_equal(simple_object, association.current_value)
+      assert_equal(321, association.id)
+      assert(association.loaded)
+    end
+
+    def test_current_value_setter_with_invalid_object
+      finder = Minitest::Mock.new
+      association = Association.new(finder: finder)
+
+      assert_raises("Invalid Association") do
+        association.current_value = "something invalid"
+      end
+    end
+
+    def test_id_setter
+      finder = Minitest::Mock.new
+      association = Association.new(
+        finder: finder,
+        id: 123,
+        current_value: "a value",
+        loaded: true
+      )
+
+      association.id = 321
+
+      refute(association.loaded)
+      assert_equal(321, association.id)
+    end
+  end
+end

--- a/test/models/user.rb
+++ b/test/models/user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class User
+  def self.find_by(*)
+    "a result"
+  end
+end


### PR DESCRIPTION
Adds module `ActiveForm::AssociationAttributes`, that defines an association method in the class that included it. It can be used like:

```ruby
class Foo
  include ActiveForm::AssociationAttributes

  association :foo
  association :bar
end
```

That defines the methods `foo`, `foo=`, `foo_id`, `foo_id=`, `bar`, `bar=`, `bar_id` and `bar_id=` on Foo instances.