### PR TITLE
Adds conditions option to association

### DIFF
--- a/lib/active_form/association_finder.rb
+++ b/lib/active_form/association_finder.rb
@@ -2,17 +2,19 @@
 
 module ActiveForm
   class AssociationFinder
-    attr_reader :class_name, :scope, :form
+    attr_reader :class_name, :scope, :conditions, :form
 
-    def initialize(form:, name:, scope: nil)
+    def initialize(form:, name:, scope: nil, conditions: nil)
       @class_name = name.to_s.classify.constantize
       @scope = scope
+      @conditions = conditions
       @form = form
     end
 
     def find(id:)
       class_name
         .yield_self { |relation| scope_relation(form, relation) }
+        .yield_self { |relation| add_conditions(relation) }
         .yield_self { |relation| relation.find_by(id: id) }
     end
 
@@ -27,6 +29,12 @@ module ActiveForm
       end
 
       relation
+    end
+
+    def add_conditions(relation)
+      return relation if conditions.blank?
+
+      relation.merge(conditions)
     end
   end
 end

--- a/test/association_finder_test.rb
+++ b/test/association_finder_test.rb
@@ -76,5 +76,27 @@ module ActiveForm
 
       assert_nil(finder.find(id: @user.id))
     end
+
+    def test_find_with_met_conditions
+      form = Minitest::Mock.new
+      finder = AssociationFinder.new(
+        name: :user,
+        form: form,
+        conditions: -> { active }
+      )
+
+      assert_instance_of(User, finder.find(id: @user.id))
+    end
+
+    def test_find_with_not_met_conditions
+      form = Minitest::Mock.new
+      finder = AssociationFinder.new(
+        name: :user,
+        form: form,
+        conditions: -> { where(active: false) }
+      )
+
+      assert_nil(finder.find(id: @user.id))
+    end
   end
 end

--- a/test/integration/association_with_conditions_test.rb
+++ b/test/integration/association_with_conditions_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "support/database_setup"
+require "models/user"
+
+module ActiveForm
+  class AssociationWithConditionsTest < Minitest::Test
+    class FormUserActive
+      include ActiveForm::Form
+
+      association :user, conditions: -> { active }
+    end
+
+    class FormUserInactive
+      include ActiveForm::Form
+
+      association :user, conditions: -> { where(active: false) }
+    end
+
+    def setup
+      @user = User.create(first_name: "Alexandre", last_name: "Saldanha")
+      @other_user = User.create(
+        first_name: "Nathália",
+        last_name: "Oliveira",
+        active: false
+      )
+    end
+
+    def test_association_with_met_conditions
+      form = FormUserActive.new(user_id: @user.id)
+
+      form_user = form.user
+
+      assert_instance_of(User, form_user)
+      assert_equal(@user.id, form_user.id)
+    end
+
+    def test_association_with_not_met_conditions
+      form = FormUserInactive.new(user_id: @user.id)
+
+      assert_nil(form.user)
+    end
+
+    def test_association_with_met_conditions_not_scope
+      form = FormUserInactive.new(user_id: @other_user.id)
+
+      form_user = form.user
+
+      assert_instance_of(User, form_user)
+      assert_equal(@other_user.id, form_user.id)
+    end
+  end
+end

--- a/test/models/team.rb
+++ b/test/models/team.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Team < ActiveRecord::Base
+  belongs_to :account
+end

--- a/test/models/user.rb
+++ b/test/models/user.rb
@@ -2,4 +2,7 @@
 
 class User < ActiveRecord::Base
   belongs_to :account
+  belongs_to :team
+
+  scope :active, -> { where(active: true) }
 end

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define do
   create_table :users, force: true do |t|
     t.string :first_name
     t.string :last_name
-    t.string :email
+    t.boolean :active, default: true
 
     t.references :account
     t.references :team


### PR DESCRIPTION
Adds a `conditions` option to the association definition. Conditions can be used to apply filters to the search without values of the own form class (the one that includes `ActiveForm::Form`).