### PR TITLE
Adds default option to association

### DIFF
--- a/lib/active_form/associations.rb
+++ b/lib/active_form/associations.rb
@@ -18,8 +18,13 @@ module ActiveForm
       end
     end
 
-    def self.has_one(name:, form:, value: nil, **options)
-      HasOne.new(name: name, form: form, value: value, finder_options: options)
+    def self.has_one(name:, form:, default: nil, **finder_options)
+      HasOne.new(
+        name: name,
+        form: form,
+        default: default,
+        finder_options: finder_options
+      )
     end
   end
 end

--- a/lib/active_form/associations/base.rb
+++ b/lib/active_form/associations/base.rb
@@ -5,12 +5,12 @@ module ActiveForm
     class Base
       attr_reader :name, :key, :form
 
-      def initialize(name:, form:, value: nil, finder_options: {})
+      def initialize(name:, form:, default: nil, finder_options: {})
         @name = name
         @form = form
         @finder_options = finder_options
 
-        initialize_value(value)
+        initialize_value(default)
       end
 
       def value=(new_value)

--- a/test/associations/base_test.rb
+++ b/test/associations/base_test.rb
@@ -44,7 +44,7 @@ module ActiveForm
         proc_value = -> { DummyValue.new(1) }
         form = Minitest::Mock.new
 
-        assoc = TestWithAssign.new(name: :foo, form: form, value: proc_value)
+        assoc = TestWithAssign.new(name: :foo, form: form, default: proc_value)
 
         assert_instance_of(DummyValue, assoc.value)
         assert(assoc.loaded?)
@@ -54,7 +54,7 @@ module ActiveForm
         form = Minitest::Mock.new
 
         assert_raises(ActiveForm::InvalidAssociationDefault) do
-          TestWithAssign.new(name: :foo, form: form, value: "value")
+          TestWithAssign.new(name: :foo, form: form, default: "value")
         end
       end
 
@@ -75,7 +75,7 @@ module ActiveForm
         form = Minitest::Mock.new
         proc_value = -> { DummyValue.new(1) }
 
-        assoc = TestWithFinder.new(name: :foo, form: form, value: proc_value)
+        assoc = TestWithFinder.new(name: :foo, form: form, default: proc_value)
 
         assert_instance_of(DummyValue, assoc.value)
       end

--- a/test/integration/association_with_default_test.rb
+++ b/test/integration/association_with_default_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "support/database_setup"
+require "models/team"
+
+module ActiveForm
+  class AssociationWithDefaultTest < Minitest::Test
+    class SampleWithDefault
+      include ActiveForm::Form
+
+      has_one :team, default: -> { Team.first }
+    end
+
+    def setup
+      @team = Team.create(name: "FooTeam")
+    end
+
+    def test_association_with_default
+      form = SampleWithDefault.new
+
+      assert_instance_of(Team, form.team)
+      assert_equal(@team.id, form.team.id)
+    end
+  end
+end


### PR DESCRIPTION
`has_one` declarations now accept a `default` option, which must be a proc for the default value the association will hold. Note that default values are restricted by the same rules as assigning a value manually (i.e. the assigned object must respond to an `id` method).