### PR TITLE
Adds class_name option to association

### DIFF
--- a/lib/active_form/errors.rb
+++ b/lib/active_form/errors.rb
@@ -23,4 +23,10 @@ module ActiveForm
       )
     end
   end
+
+  class InvalidClassName < Error
+    def initialize(finder_class, name)
+      super("Unknown constant #{finder_class} for association #{name}")
+    end
+  end
 end

--- a/test/association/loaders/base_test.rb
+++ b/test/association/loaders/base_test.rb
@@ -15,10 +15,24 @@ module ActiveForm
           end
         end
 
-        def test_load_finds_on_correct_class
+        def test_load_finds_on_default_class_name
           loader = TestLoader.new(name: :user)
 
           assert_equal(User, loader.load(123, Object.new))
+        end
+
+        def test_load_finds_on_custom_class_name
+          loader = TestLoader.new(name: :owner_user, class_name: "User")
+
+          assert_equal(User, loader.load(123, Object.new))
+        end
+
+        def test_load_unknown_class_name
+          loader = TestLoader.new(name: :foo)
+
+          assert_raises(InvalidClassName) do
+            loader.load(123, Object.new)
+          end
         end
 
         def test_load_with_scope_on_one_value

--- a/test/integration/association_with_custom_class_name_test.rb
+++ b/test/integration/association_with_custom_class_name_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "support/database_setup"
+require "support/models/user"
+
+module ActiveForm
+  class AssociationWithCustomClassNameTest < Minitest::Test
+    class FooForm
+      include ActiveForm::Form
+
+      has_one :owner_user, class_name: "User"
+    end
+
+    def setup
+      @user = User.create
+    end
+
+    def test_association_with_custom_class_name
+      form = FooForm.new(owner_user_id: @user.id)
+
+      form_user = form.owner_user
+
+      assert_instance_of(User, form_user)
+      assert_equal(@user.id, form_user.id)
+    end
+  end
+end


### PR DESCRIPTION
Adds the `class_name` option to an association definition:

```
class Form
  include Active::Form

  has_one :owner_user, class_name: "User"
end
```

The `class_name` option is useful when the association name doesn't match the class name of the record you want to search in.